### PR TITLE
Update functions.php

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -1,15 +1,23 @@
 <?php
 
 /**
- * Loads the StoreFront parent theme stylesheet.
+ * Storefront automatically loads the core CSS even if using a child theme as it is more efficient
+ * than @importing it in the child theme style.css file.
+ *
+ * Uncomment the line below if you'd like to disable the Storefront Core CSS.
+ *
+ * If you don't plan to dequeue the Storefront Core CSS you can remove the subsequent line and as well
+ * as the sf_child_theme_dequeue_style() function declaration.
  */
+//add_action( 'wp_enqueue_scripts', 'sf_child_theme_dequeue_style', 999 );
 
-function sf_child_theme_enqueue_styles() {
-
-    wp_enqueue_style( 'storefront-child-style', get_stylesheet_directory_uri() . '/style.css', array( 'storefront-style' ) );
-
+/**
+ * Dequeue the Storefront Parent theme core CSS
+ */
+function sf_child_theme_dequeue_style() {
+    wp_dequeue_style( 'storefront-style' );
+    wp_dequeue_style( 'storefront-woocommerce-style' );
 }
-add_action( 'wp_enqueue_scripts', 'sf_child_theme_enqueue_styles' );
 
 /**
  * Note: DO NOT! alter or remove the code above this text and only add your custom PHP functions below this text.


### PR DESCRIPTION
Since Storefront 1.5.3 the child themes style.css file is automatically
included so we don’t need to enqueue it manually in the child theme.

I think it’s worth including the code to disable the Storefront Core
CSS though, in case anyone wanted to do that.
